### PR TITLE
Fixing issue with scroll

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,21 @@ function ColorPicker({ value = 'rgba(175, 51, 242, 1)', onChange = () => {}, hid
   const contRef = useRef(null)
   const { width, height } = useWindowSizes()
   const [bounds, setBounds] = useState({})
+  const onScroll = () => {
+    return setBounds(contRef?.current?.getBoundingClientRect())
+  }
 
+  let a = contRef?.current
+  let els = []
+  while (a) {
+    a.addEventListener('scroll', onScroll, {once: true});
+    els.unshift(a);
+    a = a.parentNode;
+  }
+
+  setTimeout(() => setBounds(contRef?.current?.getBoundingClientRect()), 150)
   useEffect(() => {
     setBounds(contRef?.current?.getBoundingClientRect())
-    setTimeout(() => setBounds(contRef?.current?.getBoundingClientRect()), 150)
   }, [width, height])
 
   return (

--- a/src/index.js
+++ b/src/index.js
@@ -16,14 +16,14 @@ function ColorPicker({ value = 'rgba(175, 51, 242, 1)', onChange = () => {}, hid
   let a = contRef?.current
   let els = []
   while (a) {
-    a.addEventListener('scroll', onScroll, {once: true});
-    els.unshift(a);
-    a = a.parentNode;
+    a.addEventListener('scroll', onScroll, {once: true})
+    els.unshift(a)
+    a = a.parentNode
   }
 
-  setTimeout(() => setBounds(contRef?.current?.getBoundingClientRect()), 150)
   useEffect(() => {
     setBounds(contRef?.current?.getBoundingClientRect())
+    setTimeout(() => setBounds(contRef?.current?.getBoundingClientRect()), 150)
   }, [width, height])
 
   return (


### PR DESCRIPTION
When you scroll the page either window or a parent div of the colour picker, the picker doesn't work properly and selecting colour from the colour box puts the selector at the top of the box due to boundaries not being updated. I have applied a fix and this should sort the issue. 

What I've done is I added some code to go through all the parent elements of the colour picker and if scroll occurred on any of them, it would update the boundaries and resolve the issue.

I hope this helps.

Screenshot of the bug attached. Colour picker is stuck at the top of the box regardless of where I click.

<img width="319" alt="Screenshot 2022-04-01 at 13 40 14" src="https://user-images.githubusercontent.com/4902792/161187875-04a01187-8458-4a85-bb57-6c3ee42273de.png">
