### PR TITLE
fix: handle position on hue to center

### DIFF
--- a/src/Hue.js
+++ b/src/Hue.js
@@ -37,7 +37,7 @@ const Hue = () => {
       <div className="ps-rl bar-wrap-inner" onMouseUp={stopDragging}>
         <div className="c-resize ps-rl" onMouseMove={e => handleMove(e)}>
           <div
-            style={{ left: internalHue * 0.766666666666667, top: 2 }}
+            style={{ left: internalHue * 0.766666666666667, top: -2 }}
             className="handle"
             onMouseDown={handleDown}
           />


### PR DESCRIPTION
### Description
Fixes the handle position of the Hue bar not being centered.

### Screenshot
Before|After
:-:|:-:
![image](https://user-images.githubusercontent.com/31519867/178097314-22b741ad-f7f1-4b24-adb1-45aa0cfa5476.png)|![image](https://user-images.githubusercontent.com/31519867/178097328-dbb83b7f-8099-4ed7-b332-446f735fc032.png)


