### PR TITLE
Add a Jest setup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-react"]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    '@babel/preset-react',
+    '@babel/preset-env',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An easy to use color/gradient picker for React.js",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel src --out-dir lib --copy-files"
+    "build": "babel src --out-dir lib --copy-files",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -29,8 +30,10 @@
   "devDependencies": {
     "@babel/cli": "^7.17.3",
     "@babel/core": "^7.17.4",
-    "@babel/preset-env": "^7.16.11",
-    "@babel/preset-react": "^7.16.7"
+    "@babel/preset-env": "^7.18.10",
+    "@babel/preset-react": "^7.16.7",
+    "@types/jest": "^29.0.0",
+    "ts-jest": "^28.0.8"
   },
   "license": "MIT",
   "bugs": {
@@ -42,8 +45,8 @@
   },
   "dependencies": {
     "lodash.throttle": "^4.1.1",
+    "prop-types": "^15.8.1",
     "react-color-eye-dropper": "^1.0.1",
-    "tinycolor2": "^1.4.2",
-    "prop-types": "^15.8.1"
+    "tinycolor2": "^1.4.2"
   }
 }

--- a/src/gradientParser.js
+++ b/src/gradientParser.js
@@ -22,6 +22,7 @@ export const gradientParser = (input = '') => {
     hexColor: /^#([0-9a-fA-F]+)/,
     literalColor: /^([a-zA-Z]+)/,
     rgbColor: /^rgb/i,
+    spacedRgbColor: /^(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})\s+\/\s+([0-1](\.\d+)?)/,
     rgbaColor: /^rgba/i,
     hslColor: /^hsl/i,
     hsvColor: /^hsv/i,
@@ -311,9 +312,10 @@ export const gradientParser = (input = '') => {
 
   const convertRgb = (val) => {
     let capIt = isUpperCase(val?.[0]);
-    let rgb = matchListing(matchNumber)
+    const captures = scan(tokens.spacedRgbColor);
+    const [, r, g, b, a = 1] = captures || [null, ...matchListing(matchNumber)];
     return  {
-      value: `${capIt ? 'RGBA' : 'rgba'}(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, 1)`
+      value: `${capIt ? 'RGBA' : 'rgba'}(${r}, ${g}, ${b}, ${a})`
     }
   }
 

--- a/src/gradientParser.spec.js
+++ b/src/gradientParser.spec.js
@@ -1,0 +1,51 @@
+import {gradientParser} from './gradientParser';
+
+describe('gradientParser', () => {
+  it('should parse linear gradient with hex colors', () => {
+    const gradient = 'linear-gradient(45deg, #012345 0%, #6789AB 100%)'
+
+    expect(gradientParser(gradient)).toEqual({
+      colorStops: [
+        {left: 0, type: "hex", value: "012345"},
+        {left: 100, type: "hex", value: "6789AB"},
+      ],
+      orientation: {type: "angular", value: "45"},
+      type: "linear-gradient",
+    })
+  })
+
+  it('should parse linear gradient with comma-separated rgba colors', () => {
+    const gradient = 'linear-gradient(45deg, rgba(1, 2, 3, 0.123) 0%, rgba(4, 5, 6, 0.456) 100%)'
+
+    expect(gradientParser(gradient)).toEqual({
+      colorStops: [
+        {left: 0, value: "RGBA(1,2,3,0.123)"},
+        {left: 100, value: "rgba(4,5,6,0.456)"}
+      ],
+      orientation: {type: "angular", value: "45"},
+      type: "linear-gradient",
+    })
+  })
+
+  it('should parse linear gradient with comma-separated rgb colors', () => {
+    const gradient = 'linear-gradient(45deg, rgb(1, 2, 3) 0%, rgb(4, 5, 6) 100%)'
+
+    expect(gradientParser(gradient)).toEqual({
+      colorStops: [
+        {left: 0, value: "RGBA(1, 2, 3, 1)"},
+        {left: 100, value: "rgba(4, 5, 6, 1)"}
+      ],
+      orientation: {type: "angular", value: "45"},
+      type: "linear-gradient",
+    })
+  })
+
+  // TODO: Figure out pattern of "HSV" colors
+
+  // TODO: Make it accept percentages
+  // it('should parse linear gradient with hsl colors', () => {
+  //   const gradient = 'linear-gradient(45deg, hsl(0, 100%, 50%) 0%, hsl(100, 50%, 85%) 100%)'
+  //
+  //   expect(gradientParser(gradient)).toEqual({})
+  // })
+})

--- a/src/gradientParser.spec.js
+++ b/src/gradientParser.spec.js
@@ -27,6 +27,19 @@ describe('gradientParser', () => {
     })
   })
 
+  it('should parse linear gradient with rgb + alpha colors', () => {
+    const gradient = 'linear-gradient(45deg, rgb(1 2 3 / 0.123) 0%, rgb(4 5 6 / 0.456) 100%)'
+
+    expect(gradientParser(gradient)).toEqual({
+      colorStops: [
+        {left: 0, value: "RGBA(1, 2, 3, 0.123)"},
+        {left: 100, value: "rgba(4, 5, 6, 0.456)"}
+      ],
+      orientation: {type: "angular", value: "45"},
+      type: "linear-gradient",
+    })
+  })
+
   it('should parse linear gradient with comma-separated rgb colors', () => {
     const gradient = 'linear-gradient(45deg, rgb(1, 2, 3) 0%, rgb(4, 5, 6) 100%)'
 

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,4 +1,4 @@
-import {isUpperCase, getNewHsl} from './utils'
+import {isUpperCase, getNewHsl, getGradientType} from './utils'
 
 describe('isUpperCase', () => {
   it('should return true when the first letter of the string is upper-cased', () => {
@@ -23,5 +23,44 @@ describe('getNewHsl', () => {
     getNewHsl(116, 79, 19, 0.5, callback)
 
     expect(callback).toHaveBeenCalledWith(116)
+  })
+})
+
+describe('getGradientType', () => {
+  it('should pick the correct prefix of gradient values', () => {
+    const assertionMap = [
+      ['linear-gradient(30deg, #6789AB 0%, #012345 100%)', 'linear-gradient'],
+      ['-webkit-linear-gradient(30deg, #6789AB 0%, #012345 100%)', '-webkit-linear-gradient'],
+      ['-o-linear-gradient(30deg, #6789AB 0%, #012345 100%)', '-o-linear-gradient'],
+      ['-ms-linear-gradient(30deg, #6789AB 0%, #012345 100%)', '-ms-linear-gradient'],
+      ['-moz-linear-gradient(30deg, #6789AB 0%, #012345 100%)', '-moz-linear-gradient'],
+
+      ['repeating-linear-gradient(30deg, #6789AB 0%, #012345 100%)', 'repeating-linear-gradient'],
+      ['-webkit-repeating-linear-gradient(30deg, #6789AB 0%, #012345 100%)', '-webkit-repeating-linear-gradient'],
+      ['-o-repeating-linear-gradient(30deg, #6789AB 0%, #012345 100%)', '-o-repeating-linear-gradient'],
+      ['-ms-repeating-linear-gradient(30deg, #6789AB 0%, #012345 100%)', '-ms-repeating-linear-gradient'],
+      ['-moz-repeating-linear-gradient(30deg, #6789AB 0%, #012345 100%)', '-moz-repeating-linear-gradient'],
+
+      ['radial-gradient(30deg, #6789AB 0%, #012345 100%)', 'radial-gradient'],
+      ['-webkit-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-webkit-radial-gradient'],
+      ['-o-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-o-radial-gradient'],
+      ['-ms-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-ms-radial-gradient'],
+      ['-moz-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-moz-radial-gradient'],
+
+      ['repeating-radial-gradient(30deg, #6789AB 0%, #012345 100%)', 'repeating-radial-gradient'],
+      ['-webkit-repeating-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-webkit-repeating-radial-gradient'],
+      ['-o-repeating-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-o-repeating-radial-gradient'],
+      ['-ms-repeating-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-ms-repeating-radial-gradient'],
+      ['-moz-repeating-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-moz-repeating-radial-gradient'],
+    ]
+    const outputs = [];
+    const expected = [];
+
+    assertionMap.forEach(([value, expectedValue]) => {
+      outputs.push(getGradientType(value))
+      expected.push(expectedValue)
+    })
+
+    expect(outputs).toEqual(expected)
   })
 })

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,0 +1,11 @@
+import {isUpperCase} from './utils'
+
+describe('isUpperCase', () => {
+  it('should return true when the first letter of the string is upper-cased', () => {
+    expect(isUpperCase('Aloha oe')).toBe(true)
+  })
+
+  it('should return false when the first letter of the string is lower-cased', () => {
+    expect(isUpperCase('aLOHA OE')).toBe(false)
+  })
+})

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,4 +1,4 @@
-import {isUpperCase} from './utils'
+import {isUpperCase, getNewHsl} from './utils'
 
 describe('isUpperCase', () => {
   it('should return true when the first letter of the string is upper-cased', () => {
@@ -7,5 +7,21 @@ describe('isUpperCase', () => {
 
   it('should return false when the first letter of the string is lower-cased', () => {
     expect(isUpperCase('aLOHA OE')).toBe(false)
+  })
+})
+
+describe('getNewHsl', () => {
+  it('should return correct RGBA color for given HSL color', () => {
+    const callback = () => {};
+    const output = getNewHsl(116, 79, 19, 0.5, callback)
+
+    expect(output).toEqual('rgba(15, 87, 10, 0.5)')
+  })
+
+  it('should trigger callback with correct arguments', () => {
+    const callback = jest.fn();
+    getNewHsl(116, 79, 19, 0.5, callback)
+
+    expect(callback).toHaveBeenCalledWith(116)
   })
 })

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,4 +1,4 @@
-import {isUpperCase, getNewHsl, getGradientType} from './utils'
+import {isUpperCase, getNewHsl, getGradientType, getDegrees} from './utils'
 
 describe('isUpperCase', () => {
   it('should return true when the first letter of the string is upper-cased', () => {
@@ -41,23 +41,50 @@ describe('getGradientType', () => {
       ['-ms-repeating-linear-gradient(30deg, #6789AB 0%, #012345 100%)', '-ms-repeating-linear-gradient'],
       ['-moz-repeating-linear-gradient(30deg, #6789AB 0%, #012345 100%)', '-moz-repeating-linear-gradient'],
 
-      ['radial-gradient(30deg, #6789AB 0%, #012345 100%)', 'radial-gradient'],
-      ['-webkit-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-webkit-radial-gradient'],
-      ['-o-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-o-radial-gradient'],
-      ['-ms-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-ms-radial-gradient'],
-      ['-moz-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-moz-radial-gradient'],
+      ['radial-gradient(#6789AB 0%, #012345 100%)', 'radial-gradient'],
+      ['-webkit-radial-gradient(#6789AB 0%, #012345 100%)', '-webkit-radial-gradient'],
+      ['-o-radial-gradient(#6789AB 0%, #012345 100%)', '-o-radial-gradient'],
+      ['-ms-radial-gradient(#6789AB 0%, #012345 100%)', '-ms-radial-gradient'],
+      ['-moz-radial-gradient(#6789AB 0%, #012345 100%)', '-moz-radial-gradient'],
 
-      ['repeating-radial-gradient(30deg, #6789AB 0%, #012345 100%)', 'repeating-radial-gradient'],
-      ['-webkit-repeating-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-webkit-repeating-radial-gradient'],
-      ['-o-repeating-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-o-repeating-radial-gradient'],
-      ['-ms-repeating-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-ms-repeating-radial-gradient'],
-      ['-moz-repeating-radial-gradient(30deg, #6789AB 0%, #012345 100%)', '-moz-repeating-radial-gradient'],
+      ['repeating-radial-gradient(#6789AB 0%, #012345 100%)', 'repeating-radial-gradient'],
+      ['-webkit-repeating-radial-gradient(#6789AB 0%, #012345 100%)', '-webkit-repeating-radial-gradient'],
+      ['-o-repeating-radial-gradient(#6789AB 0%, #012345 100%)', '-o-repeating-radial-gradient'],
+      ['-ms-repeating-radial-gradient(#6789AB 0%, #012345 100%)', '-ms-repeating-radial-gradient'],
+      ['-moz-repeating-radial-gradient(#6789AB 0%, #012345 100%)', '-moz-repeating-radial-gradient'],
     ]
     const outputs = [];
     const expected = [];
 
     assertionMap.forEach(([value, expectedValue]) => {
       outputs.push(getGradientType(value))
+      expected.push(expectedValue)
+    })
+
+    expect(outputs).toEqual(expected)
+  })
+})
+
+describe('getDegrees', () => {
+  it('should pick the correct degree from linear gradient values', () => {
+    const assertionMap = [
+      ['linear-gradient(0deg, #6789AB 0%, #012345 100%)', 0],
+      ['-webkit-linear-gradient(1deg, #6789AB 0%, #012345 100%)', 1],
+      ['-o-linear-gradient(2deg, #6789AB 0%, #012345 100%)', 2],
+      ['-ms-linear-gradient(3deg, #6789AB 0%, #012345 100%)', 3],
+      ['-moz-linear-gradient(4deg, #6789AB 0%, #012345 100%)', 4],
+
+      ['repeating-linear-gradient(5deg, #6789AB 0%, #012345 100%)', 5],
+      ['-webkit-repeating-linear-gradient(6deg, #6789AB 0%, #012345 100%)', 6],
+      ['-o-repeating-linear-gradient(7deg, #6789AB 0%, #012345 100%)', 7],
+      ['-ms-repeating-linear-gradient(8deg, #6789AB 0%, #012345 100%)', 8],
+      ['-moz-repeating-linear-gradient(9deg, #6789AB 0%, #012345 100%)', 9],
+    ]
+    const outputs = [];
+    const expected = [];
+
+    assertionMap.forEach(([value, expectedValue]) => {
+      outputs.push(getDegrees(value))
       expected.push(expectedValue)
     })
 


### PR DESCRIPTION
# Issues

Closes #14
Closes #9 (was removed right after it was merged)

# Description

This is solely to get the structure in and start raising the questions/patterns around it. Included a few unit tests around pure functions to kickstart. We can increment the structure later on by introducing [RTL](https://testing-library.com/docs/react-testing-library/intro/) to test component rendering, but would be an overkill for this PR.

- Add tests for `isUpperCase`, `getNewHsl`, `getGradientType`, `getDegrees` and `gradientParser`
- Adjust `gradientParser` to accept RGB colors in the format of `rgb(<r> <g> <b> / <a>)`
