### PR TITLE
Forward `className` and `style`  to the element root 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,20 @@ import Picker from "./Picker";
 
 export * from './useColorPicker'
 
-function ColorPicker({ value = 'rgba(175, 51, 242, 1)', onChange = () => {}, hideControls = false, hideInputs = false, hidePresets = false, presets = [], hideEyeDrop = false, hideAdvancedSliders = false, hideColorGuide = false, hideInputType = false, width = 294, height = 294 }) {
+function ColorPicker({
+  value = 'rgba(175, 51, 242, 1)',
+  onChange = () => {},
+  hideControls = false,
+  hideInputs = false,
+  hidePresets = false,
+  presets = [],
+  hideEyeDrop = false,
+  hideAdvancedSliders = false,
+  hideColorGuide = false,
+  hideInputType = false,
+  width = 294,
+  height = 294,
+}) {
   const contRef = useRef(null);
   const [bounds, setBounds] = useState({});
 
@@ -14,8 +27,22 @@ function ColorPicker({ value = 'rgba(175, 51, 242, 1)', onChange = () => {}, hid
 
   return (
     <div ref={contRef} style={{ width: width }}>
-      <PickerContextWrapper bounds={bounds} value={value} onChange={onChange} squareSize={width} squareHeight={height}>
-        <Picker hideControls={hideControls} hideInputs={hideInputs} hidePresets={hidePresets} presets={presets} hideEyeDrop={hideEyeDrop} hideAdvancedSliders={hideAdvancedSliders} hideColorGuide={hideColorGuide} hideInputType={hideInputType} />
+      <PickerContextWrapper
+        bounds={bounds}
+        value={value}
+        onChange={onChange}
+        squareSize={width}
+        squareHeight={height}>
+        <Picker
+          hideControls={hideControls}
+          hideInputs={hideInputs}
+          hidePresets={hidePresets}
+          presets={presets}
+          hideEyeDrop={hideEyeDrop}
+          hideAdvancedSliders={hideAdvancedSliders}
+          hideColorGuide={hideColorGuide}
+          hideInputType={hideInputType}
+        />
       </PickerContextWrapper>
     </div>
   )

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ function ColorPicker({
   hideInputType = false,
   width = 294,
   height = 294,
+  className = undefined,
 }) {
   const contRef = useRef(null);
   const [bounds, setBounds] = useState({});
@@ -26,7 +27,7 @@ function ColorPicker({
   }, [])
 
   return (
-    <div ref={contRef} style={{ width: width }}>
+    <div ref={contRef} style={{ width: width }} className={className}>
       <PickerContextWrapper
         bounds={bounds}
         value={value}

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,8 @@ function ColorPicker({
   hideInputType = false,
   width = 294,
   height = 294,
-  className = undefined,
+  style = {},
+  className,
 }) {
   const contRef = useRef(null);
   const [bounds, setBounds] = useState({});
@@ -27,7 +28,7 @@ function ColorPicker({
   }, [])
 
   return (
-    <div ref={contRef} style={{ width: width }} className={className}>
+    <div ref={contRef} style={{ ...style, width: width }} className={className}>
       <PickerContextWrapper
         bounds={bounds}
         value={value}


### PR DESCRIPTION
# Description

While it's possible to target the internal elements via CSS, it's definitely annoying.

Forwarding a `style` and a `className` to the root component allows for a customization without the need for a wrapper or relying on internal naming/structure (so deeply, at least).

Also, Styled-Components works entirely based on the `className` property, so in order for `styled(GradientPicker)` to work, it has to make use of the `className` property. 

Also, I spread the props (both received and forwarded) for better diff and readability.