### PR TITLE
Fix opacity width

### DIFF
--- a/src/Opacity.js
+++ b/src/Opacity.js
@@ -49,7 +49,7 @@ const Opacity = () => {
         style={{ ...barWrapInner, width: squareSize + 30 }}
       >
         <div
-          style={{ ...cResize, ...psRl }}
+          style={{ ...cResize, ...psRl, width: squareSize }}
           onMouseDown={handleDown}
           onMouseMove={(e) => handleMove(e)}
         >


### PR DESCRIPTION
With v2.0.17 opacity (only) looks extra width:
![21F5E1C5-0BD4-4104-AC89-66CB223247A1](https://user-images.githubusercontent.com/1415463/191917322-d0302b64-a2f3-4c53-a184-10b99c95f81a.png)
