### PR TITLE
Bug fix: hitting backspace on StopPicker leads to a crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "react-best-gradient-color-picker",
-  "version": "2.0.17",
+  "version": "2.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-best-gradient-color-picker",
-      "version": "2.0.17",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "html2canvas": "^1.4.1",
         "lodash.throttle": "^4.1.1",
         "prop-types": "^15.8.1",
-        "tinycolor2": "^1.4.2",
-        "uuid": "^8.3.2"
+        "react-color-eye-dropper": "^1.0.1",
+        "robofox-react-portal": "1.0.1",
+        "tinycolor2": "^1.4.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.17.3",
@@ -9635,6 +9636,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-color-eye-dropper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-color-eye-dropper/-/react-color-eye-dropper-1.0.1.tgz",
+      "integrity": "sha512-NP/RF6zx2vEqsTe3CVbOv0vC85BqFdvAmtZpfa2rLLiESkkUJaciKwkdwpCPTjsOecl/whRK7j5P3aPKPmbHig==",
+      "dependencies": {
+        "html2canvas": "^1.4.1",
+        "robofox-react-portal": "^1.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -9856,6 +9869,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/robofox-react-portal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/robofox-react-portal/-/robofox-react-portal-1.0.1.tgz",
+      "integrity": "sha512-nh/jv6seCIcFrI5EhCywEITMru7F7VbHO2w9ipuXBW0q52PJliQMbn/9BJVpZ9DkSznwHxwlh84/QPZoy0YQfQ==",
+      "dependencies": {
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/run-parallel": {
@@ -17859,6 +17883,15 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "react-color-eye-dropper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-color-eye-dropper/-/react-color-eye-dropper-1.0.1.tgz",
+      "integrity": "sha512-NP/RF6zx2vEqsTe3CVbOv0vC85BqFdvAmtZpfa2rLLiESkkUJaciKwkdwpCPTjsOecl/whRK7j5P3aPKPmbHig==",
+      "requires": {
+        "html2canvas": "^1.4.1",
+        "robofox-react-portal": "^1.0.1"
+      }
+    },
     "react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -18024,6 +18057,14 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "robofox-react-portal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/robofox-react-portal/-/robofox-react-portal-1.0.1.tgz",
+      "integrity": "sha512-nh/jv6seCIcFrI5EhCywEITMru7F7VbHO2w9ipuXBW0q52PJliQMbn/9BJVpZ9DkSznwHxwlh84/QPZoy0YQfQ==",
+      "requires": {
+        "uuid": "^8.3.2"
       }
     },
     "run-parallel": {

--- a/src/GradientControls.jsx
+++ b/src/GradientControls.jsx
@@ -92,7 +92,7 @@ const StopPicker = () => {
       <input
         style={degreeInput}
         value={currentLeft}
-        onChange={e => handleMove(e.target.value)}
+        onChange={e => handleMove(e.target.value || 0)}
       />
     </div>
   )


### PR DESCRIPTION
Hitting backspace on StopPicker leads to an empty value which causes the app to crash, fixing this by setting the default value to 0 when the input value is empty.


https://user-images.githubusercontent.com/8860922/198544145-6a967ccb-52d0-4aab-b3d4-1952207820e2.mp4

