### PR TITLE
Added `hideOpacity` and `hideHue` props + prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,20 @@ function MyApp() {
 
 ### Props
 
-| Name             | Type         | Default                 | Description                                                      |
-| ---------------- | ------------ | ----------------------- | ---------------------------------------------------------------- |
-| value            | `string`     | 'rgba(175, 51, 242, 1)' | The starting color                                               |
-| width            | `int`        | 294                     | (optional) The width of the picker                               |
-| height           | `int`        | 294                     | (optional) The height of the picker                              |
-| hideInputs       | `boolean`    | `false`                 | (optional) hide the hex and rgba inputs                          |
-| hideControls     | `boolean`    | `false`                 | (optional) hide the solid/gradient and gradient options          |
-| hidePresets      | `boolean`    | `false`                 | (optional) hide the preset color options                         |
-| hideEyeDrop      | `boolean`    | `false`                 | (optional) hide (and disable the eye dropper tool                |
-| hideAdvancedSliders | `boolean` | `false`                 | (optional) hide the additional sliders (saturation, luminence, brightness|
-| hideColorGuide   | `boolean`    | `false`                 | (optional) hide the color guide, a tool that shows color pairings|
-| hideInputType    | `boolean`    | `false`                 | (optional) hide the input type selector, looking the type        |
-| presets          | `array`      | ['rgba(0,0,0,1)', ...]  | (optional) pass in custom preset options ['rgba()', 'rgba()', ..]|
+| Name                | Type         | Default                 | Description                                                               |
+|---------------------| ------------ | ----------------------- |---------------------------------------------------------------------------|
+| value               | `string`     | 'rgba(175, 51, 242, 1)' | The starting color                                                        |
+| width               | `int`        | 294                     | (optional) The width of the picker                                        |
+| height              | `int`        | 294                     | (optional) The height of the picker                                       |
+| hideInputs          | `boolean`    | `false`                 | (optional) hide the hex and rgba inputs                                   |
+| hideOpacity         | `boolean`    | `false`                 | (optional) hide the opacity bar                                             |
+| hideControls        | `boolean`    | `false`                 | (optional) hide the solid/gradient and gradient options                   |
+| hidePresets         | `boolean`    | `false`                 | (optional) hide the preset color options                                  |
+| hideEyeDrop         | `boolean`    | `false`                 | (optional) hide (and disable the eye dropper tool                         |
+| hideAdvancedSliders | `boolean` | `false`                 | (optional) hide the additional sliders (saturation, luminence, brightness |
+| hideColorGuide      | `boolean`    | `false`                 | (optional) hide the color guide, a tool that shows color pairings         |
+| hideInputType       | `boolean`    | `false`                 | (optional) hide the input type selector, looking the type                 |
+| presets             | `array`      | ['rgba(0,0,0,1)', ...]  | (optional) pass in custom preset options ['rgba()', 'rgba()', ..]         |
 
 ### API
 

--- a/README.md
+++ b/README.md
@@ -49,16 +49,17 @@ function MyApp() {
 ### Props
 
 | Name                | Type         | Default                 | Description                                                               |
-|---------------------| ------------ | ----------------------- |---------------------------------------------------------------------------|
+|---------------------|--------------| ----------------------- |---------------------------------------------------------------------------|
 | value               | `string`     | 'rgba(175, 51, 242, 1)' | The starting color                                                        |
 | width               | `int`        | 294                     | (optional) The width of the picker                                        |
 | height              | `int`        | 294                     | (optional) The height of the picker                                       |
 | hideInputs          | `boolean`    | `false`                 | (optional) hide the hex and rgba inputs                                   |
-| hideOpacity         | `boolean`    | `false`                 | (optional) hide the opacity bar                                             |
+| hideOpacity         | `boolean`    | `false`                 | (optional) hide the opacity bar                                           |
+| hideHue             | `boolean`    | `false`                 | (optional) hide the hue bar                                               |
 | hideControls        | `boolean`    | `false`                 | (optional) hide the solid/gradient and gradient options                   |
 | hidePresets         | `boolean`    | `false`                 | (optional) hide the preset color options                                  |
 | hideEyeDrop         | `boolean`    | `false`                 | (optional) hide (and disable the eye dropper tool                         |
-| hideAdvancedSliders | `boolean` | `false`                 | (optional) hide the additional sliders (saturation, luminence, brightness |
+| hideAdvancedSliders | `boolean`    | `false`                 | (optional) hide the additional sliders (saturation, luminence, brightness |
 | hideColorGuide      | `boolean`    | `false`                 | (optional) hide the color guide, a tool that shows color pairings         |
 | hideInputType       | `boolean`    | `false`                 | (optional) hide the input type selector, looking the type                 |
 | presets             | `array`      | ['rgba(0,0,0,1)', ...]  | (optional) pass in custom preset options ['rgba()', 'rgba()', ..]         |

--- a/src/AdvancedControls.jsx
+++ b/src/AdvancedControls.jsx
@@ -7,15 +7,8 @@ import { barWrap, psRl, barWrapInner, cResize, handle } from './style'
 const tinycolor = require('tinycolor2')
 
 const AdvancedControls = ({ openAdvanced }) => {
-  const {
-    tinyColor,
-    hue,
-    l,
-    handleChange,
-    s,
-    opacity,
-    squareSize,
-  } = usePicker()
+  const { tinyColor, hue, l, handleChange, s, opacity, squareSize } =
+    usePicker()
   const { v, s: vs } = tinyColor.toHsv()
   const satRef = useRef(null)
   const lightRef = useRef(null)
@@ -24,17 +17,17 @@ const AdvancedControls = ({ openAdvanced }) => {
   usePaintLight(lightRef, hue, s * 100, squareSize)
   usePaintBright(brightRef, hue, s * 100, squareSize)
 
-  const satDesat = value => {
+  const satDesat = (value) => {
     const { r, g, b } = tinycolor({ h: hue, s: value / 100, l }).toRgb()
     handleChange(`rgba(${r},${g},${b},${opacity})`)
   }
 
-  const setLight = value => {
+  const setLight = (value) => {
     const { r, g, b } = tinycolor({ h: hue, s, l: value / 100 }).toRgb()
     handleChange(`rgba(${r},${g},${b},${opacity})`)
   }
 
-  const setBright = value => {
+  const setBright = (value) => {
     const { r, g, b } = tinycolor({ h: hue, s: vs * 100, v: value }).toRgb()
     handleChange(`rgba(${r},${g},${b},${opacity})`)
   }
@@ -79,7 +72,7 @@ export default AdvancedControls
 const AdvBar = ({ value, callback, reffy, openAdvanced, label }) => {
   const { squareSize, inFocus } = usePicker()
   const [dragging, setDragging] = useState(false)
-  const [handleTop, setHandleTop] = useState(2);
+  const [handleTop, setHandleTop] = useState(2)
   const sliderId = `${label?.toLowerCase()}Handle`
   let left = value * (squareSize - 18)
 
@@ -91,13 +84,13 @@ const AdvBar = ({ value, callback, reffy, openAdvanced, label }) => {
     setDragging(false)
   }
 
-  const handleMove = e => {
+  const handleMove = (e) => {
     if (dragging) {
       callback(getHandleValue(e))
     }
   }
 
-  const handleClick = e => {
+  const handleClick = (e) => {
     if (!dragging) {
       callback(getHandleValue(e))
     }
@@ -139,7 +132,7 @@ const AdvBar = ({ value, callback, reffy, openAdvanced, label }) => {
       >
         <div
           className="c-resize ps-rl"
-          onMouseMove={e => handleMove(e)}
+          onMouseMove={(e) => handleMove(e)}
           style={{ ...cResize, ...psRl }}
         >
           <div
@@ -160,8 +153,8 @@ const AdvBar = ({ value, callback, reffy, openAdvanced, label }) => {
               zIndex: 10,
               textShadow: '1px 1px 1px rgba(0,0,0,.6)',
             }}
-            onMouseMove={e => handleMove(e)}
-            onClick={e => handleClick(e)}
+            onMouseMove={(e) => handleMove(e)}
+            onClick={(e) => handleClick(e)}
           >
             {label}
           </div>
@@ -170,7 +163,7 @@ const AdvBar = ({ value, callback, reffy, openAdvanced, label }) => {
             width={`${squareSize}px`}
             height="14px"
             style={{ position: 'relative', borderRadius: 14 }}
-            onClick={e => handleClick(e)}
+            onClick={(e) => handleClick(e)}
           />
         </div>
       </div>

--- a/src/ComparibleColors.jsx
+++ b/src/ComparibleColors.jsx
@@ -1,107 +1,107 @@
-import React from "react";
-import { usePicker } from "./context";
-import { psRl, df, jfe } from "./style";
+import React from 'react'
+import { usePicker } from './context'
+import { psRl, df, jfe } from './style'
 
 const ComparibleColors = ({ openComparibles }) => {
-  const { tinyColor, handleChange } = usePicker();
+  const { tinyColor, handleChange } = usePicker()
 
-  const analogous = tinyColor.analogous();
-  const monochromatic = tinyColor.monochromatic();
-  const triad = tinyColor.triad();
-  const tetrad = tinyColor.tetrad();
+  const analogous = tinyColor.analogous()
+  const monochromatic = tinyColor.monochromatic()
+  const triad = tinyColor.triad()
+  const tetrad = tinyColor.tetrad()
 
-  const handleClick = tiny => {
-    let { r, g, b, a } = tiny.toRgb();
-    handleChange(`rgba(${r},${g},${b},${a})`);
-  };
+  const handleClick = (tiny) => {
+    let { r, g, b, a } = tiny.toRgb()
+    handleChange(`rgba(${r},${g},${b},${a})`)
+  }
 
   return (
     <div
       style={{
         height: openComparibles ? 216 : 0,
-        width: "100%",
-        transition: "all 120ms linear"
+        width: '100%',
+        transition: 'all 120ms linear',
       }}
     >
       <div
         style={{
           paddingTop: 11,
-          display: openComparibles ? "" : "none",
-          ...psRl
+          display: openComparibles ? '' : 'none',
+          ...psRl,
         }}
       >
         <div
           style={{
-            textAlign: "center",
-            color: "#323136",
+            textAlign: 'center',
+            color: '#323136',
             fontSize: 13,
             fontWeight: 600,
-            position: "absolute",
+            position: 'absolute',
             top: 6.5,
-            left: 2
+            left: 2,
           }}
         >
           Color Guide
         </div>
         <div
           style={{
-            textAlign: "center",
-            color: "#323136",
+            textAlign: 'center',
+            color: '#323136',
             fontSize: 12,
             fontWeight: 500,
-            marginTop: 3
+            marginTop: 3,
           }}
         >
           Analogous
         </div>
-        <div style={{ borderRadius: 5, overflow: "hidden", ...df }}>
+        <div style={{ borderRadius: 5, overflow: 'hidden', ...df }}>
           {analogous?.map((c, key) => (
             <div
               key={key}
-              style={{ width: "20%", height: 30, background: c.toHexString() }}
+              style={{ width: '20%', height: 30, background: c.toHexString() }}
               onClick={() => handleClick(c)}
             />
           ))}
         </div>
         <div
           style={{
-            textAlign: "center",
-            color: "#323136",
+            textAlign: 'center',
+            color: '#323136',
             fontSize: 12,
             fontWeight: 500,
-            marginTop: 3
+            marginTop: 3,
           }}
         >
           Monochromatic
         </div>
-        <div style={{ borderRadius: 5, overflow: "hidden", ...df, ...jfe }}>
+        <div style={{ borderRadius: 5, overflow: 'hidden', ...df, ...jfe }}>
           {monochromatic?.map((c, key) => (
             <div
               key={key}
-              style={{ width: "20%", height: 30, background: c.toHexString() }}
+              style={{ width: '20%', height: 30, background: c.toHexString() }}
               onClick={() => handleClick(c)}
             />
           ))}
         </div>
         <div
           style={{
-            textAlign: "center",
-            color: "#323136",
+            textAlign: 'center',
+            color: '#323136',
             fontSize: 12,
             fontWeight: 500,
-            marginTop: 3
+            marginTop: 3,
           }}
         >
           Triad
         </div>
-        <div style={{ borderRadius: 5, overflow: "hidden", ...df, ...jfe }}>
+        <div style={{ borderRadius: 5, overflow: 'hidden', ...df, ...jfe }}>
           {triad?.map((c, key) => (
             <div
               key={key}
               style={{
-                width: "calc(100% / 3)",
+                width: 'calc(100% / 3)',
                 height: 28,
-                background: c.toHexString()
+                background: c.toHexString(),
               }}
               onClick={() => handleClick(c)}
             />
@@ -109,27 +109,27 @@ const ComparibleColors = ({ openComparibles }) => {
         </div>
         <div
           style={{
-            textAlign: "center",
-            color: "#323136",
+            textAlign: 'center',
+            color: '#323136',
             fontSize: 12,
             fontWeight: 500,
-            marginTop: 3
+            marginTop: 3,
           }}
         >
           Tetrad
         </div>
-        <div style={{ borderRadius: 5, overflow: "hidden", ...df, ...jfe }}>
+        <div style={{ borderRadius: 5, overflow: 'hidden', ...df, ...jfe }}>
           {tetrad?.map((c, key) => (
             <div
               key={key}
-              style={{ width: "25%", height: 28, background: c.toHexString() }}
+              style={{ width: '25%', height: 28, background: c.toHexString() }}
               onClick={() => handleClick(c)}
             />
           ))}
         </div>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default ComparibleColors;
+export default ComparibleColors

--- a/src/Controls.js
+++ b/src/Controls.js
@@ -212,7 +212,7 @@ const InputTypeDropdown = ({ openInputType, setOpenInputType }) => {
           ...controlBtn,
           ...controlBtnStyles(inputType === 'rgb'),
         }}
-        onClick={e => handleInputType(e, 'rgb')}
+        onClick={(e) => handleInputType(e, 'rgb')}
       >
         RGB
       </div>
@@ -223,7 +223,7 @@ const InputTypeDropdown = ({ openInputType, setOpenInputType }) => {
           ...controlBtn,
           ...controlBtnStyles(inputType === 'hsl'),
         }}
-        onClick={e => handleInputType(e, 'hsl')}
+        onClick={(e) => handleInputType(e, 'hsl')}
       >
         HSL
       </div>
@@ -234,7 +234,7 @@ const InputTypeDropdown = ({ openInputType, setOpenInputType }) => {
           ...controlBtn,
           ...controlBtnStyles(inputType === 'hsv'),
         }}
-        onClick={e => handleInputType(e, 'hsv')}
+        onClick={(e) => handleInputType(e, 'hsv')}
       >
         HSV
       </div>
@@ -245,7 +245,7 @@ const InputTypeDropdown = ({ openInputType, setOpenInputType }) => {
           ...controlBtn,
           ...controlBtnStyles(inputType === 'cmyk'),
         }}
-        onClick={e => handleInputType(e, 'cmyk')}
+        onClick={(e) => handleInputType(e, 'cmyk')}
       >
         CMYK
       </div>
@@ -253,7 +253,7 @@ const InputTypeDropdown = ({ openInputType, setOpenInputType }) => {
   )
 }
 
-export const controlBtnStyles = selected => {
+export const controlBtnStyles = (selected) => {
   return {
     background: selected ? 'white' : 'rgba(255,255,255,0)',
     color: selected ? '#568CF5' : 'rgb(86,86,86)',

--- a/src/EyeDropper.js
+++ b/src/EyeDropper.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import Portal from './Portal'
 import html2canvas from 'html2canvas'
 import { controlBtnStyles } from './Controls'
@@ -49,29 +49,28 @@ const DropperIcon = ({ color }) => {
 const Dropper = ({ onSelect, buttonStyle }) => {
   const [pickerCanvas, setPickerCanvas] = useState('')
   const [coverUp, setCoverUp] = useState(false)
-  const [tester, setTester] = useState('');
 
   const takePick = () => {
-    let root = document.getElementById('root');
-    setCoverUp(true);
+    let root = document.getElementById('root')
+    setCoverUp(true)
 
-    html2canvas(root).then(canvas => {
+    html2canvas(root).then((canvas) => {
       const blankCanvas = document.createElement('canvas')
       const ctx = blankCanvas.getContext('2d', { willReadFrequently: true })
-      blankCanvas.width = root.offsetWidth * 2;
-      blankCanvas.height = root.offsetHeight * 2;
-      ctx.drawImage(canvas, 0, 0);
+      blankCanvas.width = root.offsetWidth * 2
+      blankCanvas.height = root.offsetHeight * 2
+      ctx.drawImage(canvas, 0, 0)
 
       setPickerCanvas(ctx)
     })
   }
 
-  const getColorLegacy = e => {
-    e.stopPropagation();
-    let { pageX, pageY } = e;
+  const getColorLegacy = (e) => {
+    e.stopPropagation()
+    let { pageX, pageY } = e
     const x1 = pageX * 2
     const y1 = pageY * 2
-    let [r, g, b] = pickerCanvas.getImageData(x1, y1, 1, 1).data;
+    let [r, g, b] = pickerCanvas.getImageData(x1, y1, 1, 1).data
     onSelect(`rgba(${r}, ${g}, ${b}, 1)`)
     setCoverUp(false)
   }
@@ -80,16 +79,19 @@ const Dropper = ({ onSelect, buttonStyle }) => {
     if (!window.EyeDropper) {
       takePick()
     } else {
-      const eyeDropper = new window.EyeDropper();
-      const abortController = new window.AbortController();
+      const eyeDropper = new window.EyeDropper()
+      const abortController = new window.AbortController()
 
-      eyeDropper.open({ signal: abortController.signal }).then((result) => {
-        let tinyHex = tc(result.sRGBHex);
-        let { r, g, b } = tinyHex.toRgb()
-        onSelect(`rgba(${r}, ${g}, ${b}, 1)`)
-      }).catch((e) => {
-        console.log(e);
-      });
+      eyeDropper
+        .open({ signal: abortController.signal })
+        .then((result) => {
+          let tinyHex = tc(result.sRGBHex)
+          let { r, g, b } = tinyHex.toRgb()
+          onSelect(`rgba(${r}, ${g}, ${b}, 1)`)
+        })
+        .catch((e) => {
+          console.log(e)
+        })
     }
   }
 
@@ -114,7 +116,7 @@ const Dropper = ({ onSelect, buttonStyle }) => {
               height: window.innerHeight,
               cursor: 'copy',
             }}
-            onClick={e => getColorLegacy(e)}
+            onClick={(e) => getColorLegacy(e)}
           />
         </Portal>
       )}
@@ -122,4 +124,4 @@ const Dropper = ({ onSelect, buttonStyle }) => {
   )
 }
 
-export default Dropper;
+export default Dropper

--- a/src/GradientBar.js
+++ b/src/GradientBar.js
@@ -25,9 +25,9 @@ const GradientBar = () => {
     selectedColor,
     setSelectedColor,
     inFocus,
-    setInFocus
+    setInFocus,
   } = usePicker()
-  const [dragging, setDragging] = useState(false);
+  const [dragging, setDragging] = useState(false)
 
   function force90degLinear(color) {
     return color.replace(
@@ -37,32 +37,34 @@ const GradientBar = () => {
   }
 
   useEffect(() => {
-    let selectedEl = window?.document?.getElementById(`gradient-handle-${selectedColor}`);
-    selectedEl.focus();
+    let selectedEl = window?.document?.getElementById(
+      `gradient-handle-${selectedColor}`
+    )
+    selectedEl.focus()
   }, [selectedColor])
 
   const stopDragging = () => {
     setDragging(false)
   }
 
-  const handleDown = e => {
+  const handleDown = (e) => {
     if (!dragging) {
-      addPoint(e);
-      setDragging(true);
+      addPoint(e)
+      setDragging(true)
     }
   }
 
-  const handleMove = e => {
+  const handleMove = (e) => {
     if (dragging) {
       handleGradient(currentColor, getHandleValue(e))
     }
   }
 
-  const handleKeyboard = e => {
+  const handleKeyboard = (e) => {
     if (isGradient) {
       if (e.keyCode === 8) {
         if (inFocus === 'gpoint') {
-          deletePoint();
+          deletePoint()
         }
       }
     }
@@ -83,13 +85,13 @@ const GradientBar = () => {
       style={{ ...barWrap, width: squareSize + 36 }}
     >
       <div
-        id='gradient-bar'
+        id="gradient-bar"
         onMouseUp={stopDragging}
         style={{ ...psRl, ...barWrapInner, width: squareSize + 30 }}
       >
         <div
-          onMouseDown={e => handleDown(e)}
-          onMouseMove={e => handleMove(e)}
+          onMouseDown={(e) => handleDown(e)}
+          onMouseMove={(e) => handleMove(e)}
           style={{ paddingTop: 6, paddingBottom: 6 }}
         >
           <div
@@ -120,10 +122,10 @@ export default GradientBar
 export const Handle = ({ left, i, setDragging, setInFocus }) => {
   const { setSelectedColor, selectedColor, squareSize } = usePicker()
   const isSelected = selectedColor === i
-  const leftMultiplyer = (squareSize - 18) / 100;
+  const leftMultiplyer = (squareSize - 18) / 100
 
-  const handleDown = e => {
-    e.stopPropagation();
+  const handleDown = (e) => {
+    e.stopPropagation()
     setSelectedColor(i)
     setDragging(true)
   }
@@ -143,7 +145,7 @@ export const Handle = ({ left, i, setDragging, setInFocus }) => {
       onBlur={handleBlur}
       onFocus={handleFocus}
       id={`gradient-handle-${i}`}
-      onMouseDown={e => handleDown(e)}
+      onMouseDown={(e) => handleDown(e)}
       style={{ left: left * leftMultiplyer + 13, ...gradientHandleWrap }}
     >
       <div
@@ -170,7 +172,7 @@ export const Handle = ({ left, i, setDragging, setInFocus }) => {
   )
 }
 
-const handleStyle = isSelected => {
+const handleStyle = (isSelected) => {
   return {
     boxShadow: isSelected ? '0px 0px 5px 1px rgba(86, 140, 245,.95)' : '',
     border: isSelected ? '2px solid white' : '2px solid rgba(255,255,255,.75)',

--- a/src/GradientControls.jsx
+++ b/src/GradientControls.jsx
@@ -82,7 +82,7 @@ const GradientType = () => {
 const StopPicker = () => {
   const { currentLeft, handleGradient, currentColor } = usePicker()
 
-  const handleMove = newVal => {
+  const handleMove = (newVal) => {
     handleGradient(currentColor, formatInputValues(newVal, 0, 100))
   }
 
@@ -90,10 +90,10 @@ const StopPicker = () => {
     <div style={{ ...df, ...ac, ...controlBtnsWrap, paddingLeft: 8 }}>
       <StopIcon />
       <input
-        id='rbgcp-input'
+        id="rbgcp-input"
         style={degreeInput}
         value={currentLeft}
-        onChange={e => handleMove(e.target.value || 0)}
+        onChange={(e) => handleMove(e.target.value || 0)}
       />
     </div>
   )
@@ -102,7 +102,7 @@ const StopPicker = () => {
 const DegreePicker = () => {
   const { degrees, internalOnChange, value } = usePicker()
 
-  const handleDegrees = e => {
+  const handleDegrees = (e) => {
     let newValue = formatInputValues(e.target.value, 0, 360)
     const remaining = value.split(/,(.+)/)[1]
     internalOnChange(`linear-gradient(${newValue || 0}deg, ${remaining}`)
@@ -112,10 +112,10 @@ const DegreePicker = () => {
     <div style={{ ...psRl, ...controlBtnsWrap, ...df, ...ac }}>
       <DegreesIcon />
       <input
-        id='rbgcp-input'
+        id="rbgcp-input"
         style={degreeInput}
         value={degrees}
-        onChange={e => handleDegrees(e)}
+        onChange={(e) => handleDegrees(e)}
       />
       <div
         style={{
@@ -133,7 +133,7 @@ const DegreePicker = () => {
 }
 
 const DeleteBtn = () => {
-  const { deletePoint } = usePicker();
+  const { deletePoint } = usePicker()
 
   return (
     <div

--- a/src/Hue.js
+++ b/src/Hue.js
@@ -12,7 +12,7 @@ import {
 
 const Hue = () => {
   const barRef = useRef(null)
-  const { handleHue, internalHue, squareSize, inFocus, value } = usePicker()
+  const { handleHue, internalHue, squareSize } = usePicker()
   const [dragging, setDragging] = useState(false)
   usePaintHue(barRef, squareSize)
   const [handleTop, setHandleTop] = useState(2)
@@ -29,13 +29,13 @@ const Hue = () => {
     setDragging(true)
   }
 
-  const handleMove = e => {
+  const handleMove = (e) => {
     if (dragging) {
       handleHue(e)
     }
   }
 
-  const handleClick = e => {
+  const handleClick = (e) => {
     if (!dragging) {
       handleHue(e)
     }
@@ -75,7 +75,7 @@ const Hue = () => {
       >
         <div
           style={{ ...psRl, ...cResize, ...borderBox }}
-          onMouseMove={e => handleMove(e)}
+          onMouseMove={(e) => handleMove(e)}
           className="c-resize ps-rl"
         >
           <div
@@ -91,7 +91,7 @@ const Hue = () => {
             width={`${squareSize}px`}
             height="14px"
             style={{ position: 'relative', borderRadius: 14 }}
-            onClick={e => handleClick(e)}
+            onClick={(e) => handleClick(e)}
           />
         </div>
       </div>

--- a/src/Inputs.js
+++ b/src/Inputs.js
@@ -33,13 +33,13 @@ const Inputs = () => {
   )
 }
 
-export default Inputs;
+export default Inputs
 
 const HexInput = () => {
-  const { handleChange, tinyColor, opacity } = usePicker();
-  const [disable, setDisable] = useState('');
-  const hex = tinyColor.toHex();
-  const [newHex, setNewHex] = useState(hex);
+  const { handleChange, tinyColor, opacity } = usePicker()
+  const [disable, setDisable] = useState('')
+  const hex = tinyColor.toHex()
+  const [newHex, setNewHex] = useState(hex)
 
   useEffect(() => {
     if (disable !== 'hex') {
@@ -65,13 +65,13 @@ const HexInput = () => {
     }
   }
 
-  return(
+  return (
     <div style={{ width: '23%' }}>
       <input
         style={{ ...inputWrap }}
         value={newHex}
         onChange={(e) => handleHex(e)}
-        id='rbgcp-input'
+        id="rbgcp-input"
         onFocus={hexFocus}
         onBlur={hexBlur}
       />
@@ -221,7 +221,7 @@ const CMKYInputs = () => {
 }
 
 const Input = ({ value, callback, max = 100, label }) => {
-  const [temp, setTemp] = useState(value);
+  const [temp, setTemp] = useState(value)
 
   useEffect(() => {
     setTemp(value)
@@ -236,7 +236,7 @@ const Input = ({ value, callback, max = 100, label }) => {
   return (
     <div style={{ width: '18%' }}>
       <input
-        id='rbgcp-input'
+        id="rbgcp-input"
         style={{ ...inputWrap }}
         value={temp}
         onChange={(e) => onChange(e)}

--- a/src/Opacity.js
+++ b/src/Opacity.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { usePicker } from './context'
 import {
   barWrap,
@@ -11,7 +11,8 @@ import {
 } from './style'
 
 const Opacity = () => {
-  const { handleOpacity, opacity, tinyColor, squareSize, inFocus, value } = usePicker()
+  const { handleOpacity, opacity, tinyColor, squareSize, inFocus, value } =
+    usePicker()
   const [dragging, setDragging] = useState(false)
   const { r, g, b } = tinyColor.toRgb()
   const bg = `linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(${r},${g},${b},.5) 100%)`
@@ -36,7 +37,7 @@ const Opacity = () => {
     }
   }
 
-  let left = squareSize - 18;
+  let left = squareSize - 18
 
   // const handleKeyboard = (e) => {
   //   if (inFocus === 'opacityHandle') {

--- a/src/Picker.js
+++ b/src/Picker.js
@@ -12,17 +12,18 @@ const Picker = ({
   hideControls,
   hideInputs,
   hidePresets,
-                  hideOpacity,
+  hideOpacity,
+  hideHue,
   presets,
   hideEyeDrop,
   hideAdvancedSliders,
   hideColorGuide,
   hideInputType,
 }) => {
-  const { isGradient } = usePicker();
+  const { isGradient } = usePicker()
 
   return (
-    <div style={{ userSelect: 'none' }} id='rbgcp-wrapper'>
+    <div style={{ userSelect: 'none' }} id="rbgcp-wrapper">
       <Square />
       {!hideControls && (
         <Controls
@@ -33,7 +34,7 @@ const Picker = ({
         />
       )}
       {isGradient && <GradientBar />}
-      <Hue />
+      {!hideHue && <Hue />}
       {!hideOpacity && <Opacity />}
       {!hideInputs && <Inputs />}
       {!hidePresets && <Presets presets={presets} />}

--- a/src/Picker.js
+++ b/src/Picker.js
@@ -13,6 +13,7 @@ const Picker = ({
   hideControls,
   hideInputs,
   hidePresets,
+                  hideOpacity,
   presets,
   hideEyeDrop,
   hideAdvancedSliders,
@@ -34,7 +35,7 @@ const Picker = ({
       )}
       {isGradient && <GradientBar />}
       <Hue />
-      <Opacity />
+      {!hideOpacity && <Opacity />}
       {!hideInputs && <Inputs />}
       {!hidePresets && <Presets presets={presets} />}
     </div>

--- a/src/Square.js
+++ b/src/Square.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react'
+import React, { useRef, useState } from 'react'
 import throttle from 'lodash.throttle'
 import usePaintSquare from './usePaintSquare'
 import { usePicker } from './context'
@@ -19,7 +19,7 @@ const Square = () => {
   const canvas = useRef(null)
   usePaintSquare(canvas, internalHue, squareSize, squareHeight)
 
-  const handleChange = e => {
+  const handleChange = (e) => {
     const ctx = canvas?.current?.getContext('2d', { willReadFrequently: true })
     const onMouseMove = throttle(() => handleColor(e, ctx), 250)
     onMouseMove()
@@ -29,13 +29,13 @@ const Square = () => {
     setDragging(false)
   }
 
-  const handleMove = e => {
+  const handleMove = (e) => {
     if (dragging) {
       handleChange(e)
     }
   }
 
-  const handleClick = e => {
+  const handleClick = (e) => {
     if (!dragging) {
       handleChange(e)
     }
@@ -78,7 +78,7 @@ const Square = () => {
       />
       <div
         style={{ ...psRl, ...cCross }}
-        onMouseMove={e => handleMove(e)}
+        onMouseMove={(e) => handleMove(e)}
         onMouseUp={stopDragging}
       >
         <div
@@ -87,7 +87,7 @@ const Square = () => {
         />
         <div
           style={{ ...canvasWrapper, height: squareHeight }}
-          onClick={e => handleClick(e)}
+          onClick={(e) => handleClick(e)}
         >
           <canvas
             ref={canvas}

--- a/src/context.js
+++ b/src/context.js
@@ -33,7 +33,7 @@ export default function PickerContextWrapper({
   const colors = getColors(value)
   const indexedColors = colors?.map((c, i) => ({ ...c, index: i }))
   const currentColorObj =
-    indexedColors?.filter(c => isUpperCase(c.value))[0] || indexedColors[0]
+    indexedColors?.filter((c) => isUpperCase(c.value))[0] || indexedColors[0]
   const currentColor = currentColorObj?.value
   const selectedColor = currentColorObj?.index
   const currentLeft = currentColorObj?.left
@@ -48,8 +48,8 @@ export default function PickerContextWrapper({
   const [x, y] = computeSquareXY([hue, s, l], squareSize, squareHeight)
   const [previousColors, setPreviousColors] = useState([])
   const [previousGraidents, setPreviousGradients] = useState([])
-  const [inFocus, setInFocus] = useState(null);
-  const [undoLog, setUndoLog] = useState(0);
+  const [inFocus, setInFocus] = useState(null)
+  const [undoLog, setUndoLog] = useState(0)
 
   const internalOnChange = (newValue) => {
     if (newValue !== value) {
@@ -61,7 +61,7 @@ export default function PickerContextWrapper({
         setPreviousColors([value, ...previousColors?.slice(0, 8)])
       }
 
-      onChange(newValue);
+      onChange(newValue)
     }
   }
 
@@ -70,14 +70,14 @@ export default function PickerContextWrapper({
     setInternalHue(hue)
   }, [currentColor, hue])
 
-  const createGradientStr = newColors => {
+  const createGradientStr = (newColors) => {
     let sorted = newColors.sort((a, b) => a.left - b.left)
-    let colorString = sorted?.map(cc => `${cc?.value} ${cc.left}%`)
+    let colorString = sorted?.map((cc) => `${cc?.value} ${cc.left}%`)
     internalOnChange(`${gradientType}(${degreeStr}, ${colorString.join(', ')})`)
   }
 
   const handleGradient = (newColor, left = currentLeft) => {
-    let remaining = colors?.filter(c => !isUpperCase(c.value))
+    let remaining = colors?.filter((c) => !isUpperCase(c.value))
     let newColors = [
       { value: newColor.toUpperCase(), left: left },
       ...remaining,
@@ -85,7 +85,7 @@ export default function PickerContextWrapper({
     createGradientStr(newColors)
   }
 
-  const handleChange = newColor => {
+  const handleChange = (newColor) => {
     if (isGradient) {
       handleGradient(newColor)
     } else {
@@ -93,13 +93,13 @@ export default function PickerContextWrapper({
     }
   }
 
-  const handleOpacity = e => {
+  const handleOpacity = (e) => {
     let newO = getHandleValue(e) / 100
     let newColor = `rgba(${r}, ${g}, ${b}, ${newO})`
     handleChange(newColor)
   }
 
-  const handleHue = e => {
+  const handleHue = (e) => {
     let newHue = getHandleValue(e) * 3.6
     let newHsl = getNewHsl(newHue, s, l, opacity, setInternalHue)
     handleChange(newHsl)
@@ -114,7 +114,7 @@ export default function PickerContextWrapper({
     handleChange(newColor)
   }
 
-  const setSelectedColor = index => {
+  const setSelectedColor = (index) => {
     let newGradStr = colors?.map((cc, i) => ({
       ...cc,
       value: i === index ? high(cc) : low(cc),
@@ -125,17 +125,20 @@ export default function PickerContextWrapper({
   const addPoint = (e) => {
     let left = getHandleValue(e, offsetLeft)
     let newColors = [
-      ...colors.map(c => ({ ...c, value: low(c) })),
+      ...colors.map((c) => ({ ...c, value: low(c) })),
       { value: currentColor, left: left },
     ]?.sort((a, b) => a.left - b.left)
-    createGradientStr(newColors);
+    createGradientStr(newColors)
   }
 
   const deletePoint = () => {
     if (colors?.length > 2) {
-      let formatted = colors?.map((fc, i) => ({ ...fc, value: i === selectedColor - 1 ? high(fc) : low(fc) }));
-      let remaining = formatted?.filter((rc, i) => i !== selectedColor);
-      createGradientStr(remaining);
+      let formatted = colors?.map((fc, i) => ({
+        ...fc,
+        value: i === selectedColor - 1 ? high(fc) : low(fc),
+      }))
+      let remaining = formatted?.filter((rc, i) => i !== selectedColor)
+      createGradientStr(remaining)
     }
   }
 
@@ -157,17 +160,17 @@ export default function PickerContextWrapper({
   // }
 
   useEffect(() => {
-    window.addEventListener("click", handleClickFocus);
+    window.addEventListener('click', handleClickFocus)
     // window.addEventListener('keydown', handleKeyboard)
 
     return () => {
-      window.removeEventListener("click", handleClickFocus);
+      window.removeEventListener('click', handleClickFocus)
       // window.removeEventListener('keydown', handleKeyboard)
     }
   }, [inFocus, value, undoLog])
 
   const handleClickFocus = (e) => {
-    let formattedPath = e?.path?.map((el) => el.id);
+    let formattedPath = e?.path?.map((el) => el.id)
 
     if (formattedPath?.includes('gradient-bar')) {
       setInFocus('gpoint')

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ function ColorPicker({
   onChange = () => {},
   hideControls = false,
   hideInputs = false,
+  hideOpacity = false,
   hidePresets = false,
   presets = [],
   hideEyeDrop = false,
@@ -40,6 +41,7 @@ function ColorPicker({
           hideControls={hideControls}
           hideInputs={hideInputs}
           hidePresets={hidePresets}
+          hideOpacity={hideOpacity}
           presets={presets}
           hideEyeDrop={hideEyeDrop}
           hideAdvancedSliders={hideAdvancedSliders}

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ function ColorPicker({
   hideInputs = false,
   hideOpacity = false,
   hidePresets = false,
+  hideHue = false,
   presets = [],
   hideEyeDrop = false,
   hideAdvancedSliders = false,
@@ -42,6 +43,7 @@ function ColorPicker({
           hideInputs={hideInputs}
           hidePresets={hidePresets}
           hideOpacity={hideOpacity}
+          hideHue={hideHue}
           presets={presets}
           hideEyeDrop={hideEyeDrop}
           hideAdvancedSliders={hideAdvancedSliders}

--- a/src/style.js
+++ b/src/style.js
@@ -74,7 +74,7 @@ export const gradientHandleWrap = {
   paddingLeft: 2,
   paddingRight: 2,
   top: 4,
-  outline: 'none'
+  outline: 'none',
 }
 
 export const gradientHandle = {

--- a/src/useColorPicker.js
+++ b/src/useColorPicker.js
@@ -1,31 +1,32 @@
-import { useState, useEffect } from "react";
-import { getGradientType, getDegrees, isUpperCase } from "./utils";
-import { low, high, getColors, formatInputValues } from "./formatters";
-import { rgb2cmyk } from "./converters";
-import { config } from "./constants";
+import { useState, useEffect } from 'react'
+import { getGradientType, getDegrees, isUpperCase } from './utils'
+import { low, high, getColors, formatInputValues } from './formatters'
+import { rgb2cmyk } from './converters'
+import { config } from './constants'
 
-const { defaultColor, defaultGradient } = config;
-var tc = require("tinycolor2");
+const { defaultColor, defaultGradient } = config
+var tc = require('tinycolor2')
 
 export const useColorPicker = (value, onChange) => {
-
   if (!value || !onChange) {
-    console.log('RBGCP ERROR - YOU MUST PASS A VALUE AND CALLBACK TO THE useColorPicker HOOK')
+    console.log(
+      'RBGCP ERROR - YOU MUST PASS A VALUE AND CALLBACK TO THE useColorPicker HOOK'
+    )
   }
 
-  const isGradient = value?.includes("gradient");
-  const gradientType = getGradientType(value);
-  const degrees = getDegrees(value);
+  const isGradient = value?.includes('gradient')
+  const gradientType = getGradientType(value)
+  const degrees = getDegrees(value)
   const degreeStr =
-    gradientType === "linear-gradient" ? `${degrees}deg` : "circle";
-  const colors = getColors(value);
-  const indexedColors = colors?.map((c, i) => ({ ...c, index: i }));
+    gradientType === 'linear-gradient' ? `${degrees}deg` : 'circle'
+  const colors = getColors(value)
+  const indexedColors = colors?.map((c, i) => ({ ...c, index: i }))
   const currentColorObj =
-    indexedColors?.filter(c => isUpperCase(c.value))[0] || indexedColors[0];
-  const currentColor = currentColorObj?.value;
-  const selectedPoint = currentColorObj?.index;
-  const currentLeft = currentColorObj?.left;
-  const [previousColors, setPreviousColors] = useState([]);
+    indexedColors?.filter((c) => isUpperCase(c.value))[0] || indexedColors[0]
+  const currentColor = currentColorObj?.value
+  const selectedPoint = currentColorObj?.index
+  const currentLeft = currentColorObj?.left
+  const [previousColors, setPreviousColors] = useState([])
 
   const getGradientObject = () => {
     if (value) {
@@ -34,204 +35,206 @@ export const useColorPicker = (value, onChange) => {
           isGradient: true,
           gradientType: gradientType,
           degrees: degreeStr,
-          colors: colors?.map((c) => ({ ...c, value: c.value?.toLowerCase() }))
+          colors: colors?.map((c) => ({ ...c, value: c.value?.toLowerCase() })),
         }
       } else {
         return {
           isGradient: false,
           gradientType: null,
           degrees: null,
-          colors: colors?.map((c) => ({ ...c, value: c.value?.toLowerCase() }))
+          colors: colors?.map((c) => ({ ...c, value: c.value?.toLowerCase() })),
         }
       }
     } else {
-      console.log('RBGCP ERROR - YOU MUST PASS A VALUE AND CALLBACK TO THE useColorPicker HOOK')
+      console.log(
+        'RBGCP ERROR - YOU MUST PASS A VALUE AND CALLBACK TO THE useColorPicker HOOK'
+      )
     }
   }
 
-  const tiny = tc(currentColor);
-  const { r, g, b, a } = tiny.toRgb();
-  const { h, s, l } = tiny.toHsl();
+  const tiny = tc(currentColor)
+  const { r, g, b, a } = tiny.toRgb()
+  const { h, s, l } = tiny.toHsl()
 
   useEffect(() => {
     if (tc(currentColor)?.isValid() && previousColors[0] !== currentColor) {
-      setPreviousColors([currentColor, ...previousColors?.slice(0, 19)]);
+      setPreviousColors([currentColor, ...previousColors?.slice(0, 19)])
     }
-  }, [currentColor, previousColors]);
+  }, [currentColor, previousColors])
 
   const setLinear = () => {
-    const remaining = value.split(/,(.+)/)[1];
-    onChange(`linear-gradient(90deg, ${remaining}`);
-  };
+    const remaining = value.split(/,(.+)/)[1]
+    onChange(`linear-gradient(90deg, ${remaining}`)
+  }
 
   const setRadial = () => {
-    const remaining = value.split(/,(.+)/)[1];
-    onChange(`radial-gradient(circle, ${remaining}`);
-  };
+    const remaining = value.split(/,(.+)/)[1]
+    onChange(`radial-gradient(circle, ${remaining}`)
+  }
 
-  const setDegrees = newDegrees => {
-    const remaining = value.split(/,(.+)/)[1];
+  const setDegrees = (newDegrees) => {
+    const remaining = value.split(/,(.+)/)[1]
     onChange(
       `linear-gradient(${formatInputValues(
         newDegrees,
         0,
         360
       )}deg, ${remaining}`
-    );
-    if (gradientType !== "linear-gradient") {
+    )
+    if (gradientType !== 'linear-gradient') {
       console.log(
-        "Warning: you are updating degrees when the gradient type is not linear. This will change the gradients type which may be undesired"
-      );
+        'Warning: you are updating degrees when the gradient type is not linear. This will change the gradients type which may be undesired'
+      )
     }
-  };
+  }
 
-  const setSolid = startingColor => {
-    let newValue = startingColor || defaultColor;
-    onChange(newValue);
-  };
+  const setSolid = (startingColor) => {
+    let newValue = startingColor || defaultColor
+    onChange(newValue)
+  }
 
-  const setGradient = startingGradiant => {
-    let newValue = startingGradiant || defaultGradient;
-    onChange(newValue);
-  };
+  const setGradient = (startingGradiant) => {
+    let newValue = startingGradiant || defaultGradient
+    onChange(newValue)
+  }
 
-  const createGradientStr = newColors => {
-    let sorted = newColors.sort((a, b) => a.left - b.left);
-    let colorString = sorted?.map(cc => `${cc?.value} ${cc.left}%`);
-    onChange(`${gradientType}(${degreeStr}, ${colorString.join(", ")})`);
-  };
+  const createGradientStr = (newColors) => {
+    let sorted = newColors.sort((a, b) => a.left - b.left)
+    let colorString = sorted?.map((cc) => `${cc?.value} ${cc.left}%`)
+    onChange(`${gradientType}(${degreeStr}, ${colorString.join(', ')})`)
+  }
 
   const handleGradient = (newColor, left = currentLeft) => {
-    let remaining = colors?.filter(c => !isUpperCase(c.value));
+    let remaining = colors?.filter((c) => !isUpperCase(c.value))
     let newColors = [
       { value: newColor.toUpperCase(), left: left },
-      ...remaining
-    ];
-    createGradientStr(newColors);
-  };
+      ...remaining,
+    ]
+    createGradientStr(newColors)
+  }
 
-  const handleChange = newColor => {
+  const handleChange = (newColor) => {
     if (isGradient) {
-      handleGradient(newColor);
+      handleGradient(newColor)
     } else {
-      onChange(newColor);
+      onChange(newColor)
     }
-  };
+  }
 
-  const setR = newR => {
-    let newVal = formatInputValues(newR, 0, 255);
-    handleChange(`rgba(${newVal}, ${g}, ${b}, ${a})`);
-  };
+  const setR = (newR) => {
+    let newVal = formatInputValues(newR, 0, 255)
+    handleChange(`rgba(${newVal}, ${g}, ${b}, ${a})`)
+  }
 
-  const setG = newG => {
-    let newVal = formatInputValues(newG, 0, 255);
-    handleChange(`rgba(${r}, ${newVal}, ${b}, ${a})`);
-  };
+  const setG = (newG) => {
+    let newVal = formatInputValues(newG, 0, 255)
+    handleChange(`rgba(${r}, ${newVal}, ${b}, ${a})`)
+  }
 
-  const setB = newB => {
-    let newVal = formatInputValues(newB, 0, 255);
-    handleChange(`rgba(${r}, ${g}, ${newVal}, ${a})`);
-  };
+  const setB = (newB) => {
+    let newVal = formatInputValues(newB, 0, 255)
+    handleChange(`rgba(${r}, ${g}, ${newVal}, ${a})`)
+  }
 
-  const setA = newA => {
-    let newVal = formatInputValues(newA, 0, 100);
-    handleChange(`rgba(${r}, ${g}, ${b}, ${newVal / 100})`);
-  };
+  const setA = (newA) => {
+    let newVal = formatInputValues(newA, 0, 100)
+    handleChange(`rgba(${r}, ${g}, ${b}, ${newVal / 100})`)
+  }
 
-  const setHue = newHue => {
-    let newVal = formatInputValues(newHue, 0, 360);
-    let tinyNew = tc({ h: newVal, s: s, l: l });
-    let { r, g, b } = tinyNew.toRgb();
-    handleChange(`rgba(${r}, ${g}, ${b}, ${a})`);
-  };
+  const setHue = (newHue) => {
+    let newVal = formatInputValues(newHue, 0, 360)
+    let tinyNew = tc({ h: newVal, s: s, l: l })
+    let { r, g, b } = tinyNew.toRgb()
+    handleChange(`rgba(${r}, ${g}, ${b}, ${a})`)
+  }
 
-  const setSaturation = newSat => {
-    let newVal = formatInputValues(newSat, 0, 100);
-    let tinyNew = tc({ h: h, s: newVal / 100, l: l });
-    let { r, g, b } = tinyNew.toRgb();
-    handleChange(`rgba(${r}, ${g}, ${b}, ${a})`);
-  };
+  const setSaturation = (newSat) => {
+    let newVal = formatInputValues(newSat, 0, 100)
+    let tinyNew = tc({ h: h, s: newVal / 100, l: l })
+    let { r, g, b } = tinyNew.toRgb()
+    handleChange(`rgba(${r}, ${g}, ${b}, ${a})`)
+  }
 
-  const setLightness = newLight => {
-    let newVal = formatInputValues(newLight, 0, 100);
-    let tinyNew = tc({ h: h, s: s, l: newVal / 100 });
+  const setLightness = (newLight) => {
+    let newVal = formatInputValues(newLight, 0, 100)
+    let tinyNew = tc({ h: h, s: s, l: newVal / 100 })
     if (tinyNew?.isValid()) {
-      let { r, g, b } = tinyNew.toRgb();
-      handleChange(`rgba(${r}, ${g}, ${b}, ${a})`);
+      let { r, g, b } = tinyNew.toRgb()
+      handleChange(`rgba(${r}, ${g}, ${b}, ${a})`)
     } else {
       console.log(
-        "The new color was invalid, perhaps the lightness you passed in was a decimal? Please pass the new value between 0 - 100"
-      );
+        'The new color was invalid, perhaps the lightness you passed in was a decimal? Please pass the new value between 0 - 100'
+      )
     }
-  };
+  }
 
   const valueToHSL = () => {
-    return tiny.toHslString();
-  };
+    return tiny.toHslString()
+  }
 
   const valueToHSV = () => {
-    return tiny.toHsvString();
-  };
+    return tiny.toHsvString()
+  }
 
   const valueToHex = () => {
-    return tiny.toHexString();
-  };
+    return tiny.toHexString()
+  }
 
   const valueToCmyk = () => {
-    let { c, m, y, k } = rgb2cmyk(r, g, b);
-    return `cmyk(${c}, ${m}, ${y}, ${k})`;
-  };
+    let { c, m, y, k } = rgb2cmyk(r, g, b)
+    return `cmyk(${c}, ${m}, ${y}, ${k})`
+  }
 
-  const setSelectedPoint = index => {
+  const setSelectedPoint = (index) => {
     if (isGradient) {
       let newGradStr = colors?.map((cc, i) => ({
         ...cc,
-        value: i === index ? high(cc) : low(cc)
-      }));
-      createGradientStr(newGradStr);
+        value: i === index ? high(cc) : low(cc),
+      }))
+      createGradientStr(newGradStr)
     } else {
       console.log(
-        "This function is only relevant when the picker is in gradient mode"
-      );
+        'This function is only relevant when the picker is in gradient mode'
+      )
     }
-  };
+  }
 
-  const addPoint = left => {
+  const addPoint = (left) => {
     let newColors = [
-      ...colors.map(c => ({ ...c, value: low(c) })),
-      { value: currentColor, left: left }
-    ];
-    createGradientStr(newColors);
+      ...colors.map((c) => ({ ...c, value: low(c) })),
+      { value: currentColor, left: left },
+    ]
+    createGradientStr(newColors)
     if (!left) {
       console.log(
-        "You did not pass a stop value (left amount) for the new color point so it defaulted to 50"
-      );
+        'You did not pass a stop value (left amount) for the new color point so it defaulted to 50'
+      )
     }
-  };
+  }
 
-  const deletePoint = index => {
+  const deletePoint = (index) => {
     if (colors?.length > 2) {
-      let pointToDelete = index || selectedPoint;
-      let remaining = colors?.filter((rc, i) => i !== pointToDelete);
-      createGradientStr(remaining);
+      let pointToDelete = index || selectedPoint
+      let remaining = colors?.filter((rc, i) => i !== pointToDelete)
+      createGradientStr(remaining)
       if (!index) {
         console.log(
-          "You did not pass in the index of the point you wanted to delete so the function default to the currently selected point"
-        );
+          'You did not pass in the index of the point you wanted to delete so the function default to the currently selected point'
+        )
       }
     } else {
       console.log(
-        "A gradient must have atleast two colors, disable your delete button when necessary"
-      );
+        'A gradient must have atleast two colors, disable your delete button when necessary'
+      )
     }
-  };
+  }
 
-  const setPointLeft = left => {
-    handleGradient(currentColor, formatInputValues(left, 0, 100));
-  };
+  const setPointLeft = (left) => {
+    handleGradient(currentColor, formatInputValues(left, 0, 100))
+  }
 
-  const rgbaArr = [r, g, b, a];
-  const hslArr = [h, s, l];
+  const rgbaArr = [r, g, b, a]
+  const hslArr = [h, s, l]
 
   return {
     setLinear,
@@ -262,6 +265,6 @@ export const useColorPicker = (value, onChange) => {
     rgbaArr,
     hslArr,
     previousColors,
-    getGradientObject
-  };
-};
+    getGradientObject,
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,8 +70,8 @@ export const isUpperCase = (str) => {
 }
 
 export const compareGradients = (g1, g2) => {
-  let ng1 = g1?.toLowerCase()?.replaceAll(' ', '');
-  let ng2 = g2?.toLowerCase()?.replaceAll(' ', '');
+  let ng1 = g1?.toLowerCase()?.replaceAll(' ', '')
+  let ng2 = g2?.toLowerCase()?.replaceAll(' ', '')
 
   if (ng1 === ng2) {
     return true


### PR DESCRIPTION
Hi,

I'm using this picker in my project and it was quite bothersome to hide the opacity bar via CSS. I thought maybe some ppl may have the same problem and decided to create this PR. Also added the option the hide the Hue bar because why not.

Please check the new `hideOpacity` and `hideHue` props. I basically just looked at existing `hide...` props and replicated their behaviour.

In addition I noticed that you have prettier rules defined but they weren't applied everywhere, so I just ran prettier for all of them, hence the many changes. 

WDYT?

---

Also I was thinking about introducing some structure in the `src` folder, since currently everything (hooks, components, tests, etc.) is in just the one `src` folder. Could split it up a little for better overview but I can create a separate PR with suggestion if you like?

Cheers