### PR TITLE
Expose `config` object to enable overwriting default colors and other settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,35 @@ function MyApp() {
 }
 ```
 
+### Custom Default Config Example
+You can pass custom config overrides via `config` prop.
+
+Note that if you use the `useColorPicker` hook, you need to pass the config object to both the hook and the `ColorPicker` component.
+
+```js
+import React from 'react'
+import ColorPicker, { useColorPicker } from 'react-best-gradient-color-picker'
+
+function MyApp() {
+  const customConfig = {
+    barSize: 20, // default is 18
+    crossSize: 20, // default is 18
+    inputSize: 35, // default is 40
+    delay: 100, // default is 150
+    defaultColor: 'rgba(175, 51, 242, 1)',
+    defaultGradient: 'linear-gradient(135deg, rgba(2,0,36,1) 0%, rgba(9,9,121,1) 35%, rgba(0,212,255,1) 100%)',
+  }
+
+  const { color, setColor } = useColorPicker(color, setColor, customConfig);
+
+  return (
+    <div>
+      <ColorPicker config={customConfig} />
+    </div>
+  )
+}
+```
+
 ### Getting Value in Object Form
 The picker returns the new value as a css gradient string but you may need it parsed as an object. This can easily be accomplised by using the getGradientObject function returned by the useColorPicker hook like so:
 

--- a/src/components/AdvancedControls.tsx
+++ b/src/components/AdvancedControls.tsx
@@ -21,7 +21,7 @@ const AdvBar = ({
   openAdvanced: boolean
   label: string
 }) => {
-  const { squareWidth, classes } = usePicker()
+  const { squareWidth, classes, config } = usePicker()
   const [dragging, setDragging] = useState<boolean>(false)
   const [handleTop, setHandleTop] = useState<number>(2)
   const left = value * (squareWidth - 18)
@@ -36,13 +36,13 @@ const AdvBar = ({
 
   const handleMove = (e: any) => {
     if (dragging) {
-      callback(getHandleValue(e))
+      callback(getHandleValue(e, config.barSize))
     }
   }
 
   const handleClick = (e: any) => {
     if (!dragging) {
-      callback(getHandleValue(e))
+      callback(getHandleValue(e, config.barSize))
     }
   }
 

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -2,13 +2,10 @@ import React, { useState } from 'react'
 import { SlidersIcon, InputsIcon, PaletteIcon } from './icon.js'
 import { usePicker } from '../context.js'
 import EyeDropper from './EyeDropper.js'
-import { config } from '../constants.js'
 import AdvancedControls from './AdvancedControls.js'
 import ComparibleColors from './ComparibleColors.js'
 import GradientControls from './GradientControls.js'
 import { LocalesProps } from '../shared/types.js'
-
-var { defaultColor, defaultGradient } = config
 
 const Controls = ({
   locales,
@@ -33,7 +30,8 @@ const Controls = ({
   hideGradientAngle?: boolean
   hideGradientStop?: boolean
 }) => {
-  const { onChange, isGradient, handleChange, classes, previous } = usePicker()
+  const { onChange, isGradient, handleChange, classes, previous, config } = usePicker()
+  const { defaultColor, defaultGradient } = config
   const [openComparibles, setOpenComparibles] = useState(false)
   const [openInputType, setOpenInputType] = useState(false)
   const [openAdvanced, setOpenAdvanced] = useState(false)

--- a/src/components/GradientBar.tsx
+++ b/src/components/GradientBar.tsx
@@ -90,6 +90,7 @@ const GradientBar = () => {
     deletePoint,
     isGradient,
     selectedColor,
+    config,
   } = usePicker()
   const [dragging, setDragging] = useState(false)
   const [inFocus, setInFocus] = useState<string | null>(null)
@@ -102,7 +103,7 @@ const GradientBar = () => {
   }
 
   const addPoint = (e: any) => {
-    const left = getHandleValue(e)
+    const left = getHandleValue(e, config.barSize)
     const newColors = [
       ...colors.map((c: any) => ({ ...c, value: low(c) })),
       { value: currentColor, left: left },
@@ -132,7 +133,7 @@ const GradientBar = () => {
 
   const handleMove = (e: any) => {
     if (dragging) {
-      handleGradient(currentColor, getHandleValue(e))
+      handleGradient(currentColor, getHandleValue(e, config.barSize))
     }
   }
 

--- a/src/components/Hue.tsx
+++ b/src/components/Hue.tsx
@@ -6,7 +6,7 @@ import tinycolor from 'tinycolor2'
 
 const Hue = () => {
   const barRef = useRef<HTMLCanvasElement>(null)
-  const { handleChange, squareWidth, hc, setHc } = usePicker()
+  const { handleChange, squareWidth, hc, setHc, config } = usePicker()
   const [dragging, setDragging] = useState(false)
   usePaintHue(barRef, squareWidth)
 
@@ -19,7 +19,7 @@ const Hue = () => {
   }
 
   const handleHue = (e: any) => {
-    const newHue = getHandleValue(e) * 3.6
+    const newHue = getHandleValue(e, config.barSize) * 3.6
     const tinyHsv = tinycolor({ h: newHue, s: hc?.s, v: hc?.v })
     const { r, g, b } = tinyHsv.toRgb()
     handleChange(`rgba(${r}, ${g}, ${b}, ${hc.a})`)

--- a/src/components/Opacity.tsx
+++ b/src/components/Opacity.tsx
@@ -3,7 +3,7 @@ import { usePicker } from '../context.js'
 import { getHandleValue } from '../utils/utils.js'
 
 const Opacity = () => {
-  const { handleChange, hc = {}, squareWidth, classes } = usePicker()
+  const { handleChange, hc = {}, squareWidth, classes, config } = usePicker()
   const [dragging, setDragging] = useState(false)
   const { r, g, b } = hc
   const bg = `linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(${r},${g},${b},.5) 100%)`
@@ -17,7 +17,7 @@ const Opacity = () => {
   }
 
   const handleOpacity = (e: any) => {
-    const newO = getHandleValue(e) / 100
+    const newO = getHandleValue(e, config.barSize) / 100
     const newColor = `rgba(${r}, ${g}, ${b}, ${newO})`
     handleChange(newColor)
   }

--- a/src/components/Square.tsx
+++ b/src/components/Square.tsx
@@ -4,15 +4,13 @@ import throttle from 'lodash.throttle'
 import { usePicker } from '../context.js'
 import tinycolor from 'tinycolor2'
 import { computePickerPosition, computeSquareXY } from '../utils/utils.js'
-import { config } from '../constants.js'
-
-const { crossSize } = config
 
 const Square = () => {
-  const { hc, classes, squareWidth, squareHeight, handleChange } = usePicker()
+  const { hc, classes, squareWidth, squareHeight, handleChange, config } = usePicker()
+  const { crossSize } = config
   const [dragging, setDragging] = useState(false)
   const canvas = useRef<HTMLCanvasElement>(null)
-  const [x, y] = computeSquareXY(hc?.s, hc?.v * 100, squareWidth, squareHeight)
+  const [x, y] = computeSquareXY(hc?.s, hc?.v * 100, squareWidth, squareHeight, crossSize)
   const [dragPos, setDragPos] = useState({ x, y })
 
   usePaintSquare(canvas, hc?.h, squareWidth, squareHeight)
@@ -25,7 +23,7 @@ const Square = () => {
 
   const handleColor = (e: any) => {
     const onMouseMove = throttle(() => {
-      const [x, y] = computePickerPosition(e)
+      const [x, y] = computePickerPosition(e, crossSize)
       if (x && y) {
         const x1 = Math.min(x + crossSize / 2, squareWidth - 1)
         const y1 = Math.min(y + crossSize / 2, squareHeight - 1)

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,10 +1,12 @@
 import React, { useRef } from 'react'
 import PickerContextWrapper from '../context.js'
 import Picker from './Picker.js'
-import { LocalesProps } from '../shared/types.js'
-import { defaultLocales } from '../constants.js'
+import { Config, LocalesProps } from '../shared/types.js'
+import { config, defaultLocales } from '../constants.js'
 import { objectToString } from '../utils/utils.js'
 import coreCss from '../core.module.css'
+
+const defaultConfig = config;
 
 type ColorPickerProps = {
   value?: string
@@ -30,6 +32,7 @@ type ColorPickerProps = {
   className?: any
   locales?: LocalesProps
   disableDarkMode?: boolean
+  config?: Config
 }
 
 export function ColorPicker({
@@ -55,6 +58,7 @@ export function ColorPicker({
   height = 294,
   style = {},
   className,
+  config = defaultConfig,
 }: ColorPickerProps) {
   const safeValue = objectToString(value)
   const contRef = useRef<HTMLDivElement>(null)
@@ -62,6 +66,7 @@ export function ColorPicker({
   return (
     <div ref={contRef} className={className} style={{ ...style, width: width }}>
       <PickerContextWrapper
+        config={config}
         value={safeValue}
         classes={coreCss}
         onChange={onChange}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,6 @@
-export const config = {
+import { Config } from './shared/types.js'
+
+export const config: Config = {
   barSize: 18,
   crossSize: 18,
   inputSize: 40,

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -7,12 +7,13 @@ import React, {
 } from 'react'
 import { isUpperCase, getColorObj, getDetails } from './utils/utils.js'
 import { low, high, getColors } from './utils/formatters.js'
-import { GradientProps } from './shared/types.js'
+import { Config, GradientProps } from './shared/types.js'
 import tinycolor from 'tinycolor2'
 
 const PickerContext = createContext<PickerContextProps | null>(null)
 
 export default function PickerContextWrapper({
+  config,
   value,
   classes,
   children,
@@ -21,9 +22,9 @@ export default function PickerContextWrapper({
   hideOpacity,
   squareHeight,
 }: PCWProps) {
-  const colors = getColors(value)
+  const colors = getColors(value, config.defaultColor, config.defaultGradient)
   const { degrees, degreeStr, isGradient, gradientType } = getDetails(value)
-  const { currentColor, selectedColor, currentLeft } = getColorObj(colors)
+  const { currentColor, selectedColor, currentLeft } = getColorObj(colors, config.defaultGradient)
   const [inputType, setInputType] = useState('rgb')
   const [previous, setPrevious] = useState({})
   const tinyColor = tinycolor(currentColor)
@@ -83,6 +84,7 @@ export default function PickerContextWrapper({
   }
 
   const pickerContext = {
+    config,
     hc,
     setHc,
     value,
@@ -126,6 +128,7 @@ export function usePicker() {
 }
 
 type PCWProps = {
+  config: Config
   classes: any
   value: string
   squareWidth: number
@@ -136,6 +139,7 @@ type PCWProps = {
 }
 
 export type PickerContextProps = {
+  config: Config
   hc: any
   classes: any
   value: string

--- a/src/hooks/useColorPicker.ts
+++ b/src/hooks/useColorPicker.ts
@@ -4,17 +4,19 @@ import { low, high, getColors, formatInputValues } from '../utils/formatters.js'
 import { rgb2cmyk } from '../utils/converters.js'
 import { config } from '../constants.js'
 import tc from 'tinycolor2'
-import { ColorsProps, GradientProps } from '../shared/types.js'
+import { ColorsProps, Config, GradientProps } from '../shared/types.js'
 
-const { defaultColor, defaultGradient } = config
+const defaultConfig = config;
 
 export const useColorPicker = (
   value: string,
-  onChange: (arg0: string) => void
+  onChange: (arg0: string) => void,
+  config: Config = defaultConfig,
 ) => {
-  const colors = getColors(value)
+  const { defaultColor, defaultGradient } = config
+  const colors = getColors(value, defaultColor, defaultGradient)
   const { degrees, degreeStr, isGradient, gradientType } = getDetails(value)
-  const { currentColor, selectedColor, currentLeft } = getColorObj(colors)
+  const { currentColor, selectedColor, currentLeft } = getColorObj(colors, defaultGradient)
   const [previousColors, setPreviousColors] = useState([])
 
   const getGradientObject = () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -30,3 +30,12 @@ export type ThemeMode = {
   highlights?: string
   accent?: string
 }
+
+export type Config = {
+  barSize: number
+  crossSize: number
+  inputSize: number
+  delay: number
+  defaultColor: string
+  defaultGradient: string
+}

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,8 +1,5 @@
-import { config } from '../constants.js'
 import { ColorsProps } from '../shared/types.js'
 import { gradientParser } from './gradientParser.js'
-
-const { defaultColor, defaultGradient } = config
 
 export const low = (color: ColorsProps) => {
   return color.value.toLowerCase()
@@ -12,7 +9,7 @@ export const high = (color: ColorsProps) => {
   return color.value.toUpperCase()
 }
 
-export const getColors = (value: string) => {
+export const getColors = (value: string, defaultColor: string, defaultGradient: string) => {
   const isGradient = value?.includes('gradient')
   if (isGradient) {
     const isConic = value?.includes('conic')

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,8 +1,5 @@
 import { formatInputValues } from './formatters.js'
 import { ColorsProps } from '../shared/types.js'
-import { config } from '../constants.js'
-
-const { barSize, crossSize } = config
 
 export const safeBounds = (e: any) => {
   const client = e.target.parentNode.getBoundingClientRect()
@@ -16,7 +13,7 @@ export const safeBounds = (e: any) => {
   }
 }
 
-export function getHandleValue(e: any) {
+export function getHandleValue(e: any, barSize: number) {
   const { offsetLeft, clientWidth } = safeBounds(e)
   const pos = e.clientX - offsetLeft - barSize / 2
   const adjuster = clientWidth - 18
@@ -28,7 +25,8 @@ export function computeSquareXY(
   s: number,
   v: number,
   squareWidth: number,
-  squareHeight: number
+  squareHeight: number,
+  crossSize: number
 ) {
   const x = s * squareWidth - crossSize / 2
   const y = ((100 - v) / 100) * squareHeight - crossSize / 2
@@ -44,7 +42,7 @@ const getClientXY = (e: any) => {
   }
 }
 
-export function computePickerPosition(e: any) {
+export function computePickerPosition(e: any, crossSize: number) {
   const { offsetLeft, offsetTop, clientWidth, clientHeight } = safeBounds(e)
   const { clientX, clientY } = getClientXY(e)
 
@@ -123,7 +121,7 @@ export const objectToString = (value: any) => {
   }
 }
 
-export const getColorObj = (colors: ColorsProps[]) => {
+export const getColorObj = (colors: ColorsProps[], defaultGradient: string) => {
   const idxCols = colors?.map((c: ColorsProps, i: number) => ({
     ...c,
     index: i,
@@ -133,7 +131,7 @@ export const getColorObj = (colors: ColorsProps[]) => {
   const ccObj = upperObj || idxCols[0]
 
   return {
-    currentColor: ccObj?.value || config?.defaultGradient,
+    currentColor: ccObj?.value || defaultGradient,
     selectedColor: ccObj?.index || 0,
     currentLeft: ccObj?.left || 0,
   }


### PR DESCRIPTION
This PR allows the user to supply their own `config` object to override the defaults set it `src/constants.ts`

Main reason for this is I wanted to set the default gradient that is chosen when the user switch modes.

What has changed is `config` is now typed to:
```
export type Config = {
  barSize: number
  crossSize: number
  inputSize: number
  delay: number
  defaultColor: string
  defaultGradient: string
}
```
and I have put a config object in both the `<PickerContext />` as well as the `useColorPicker` hook as I believe those are the only two places where the user would reasonable input these options. Both of these components fallback to the original `options` object if none is provided.

Ideally I would like the option to only be set at one place as now you would need to supply the same `config` object to both the `<ColorPicker>` component and the `useColorPicker` hook if you use both 🥴 