### PR TITLE
Fix: Prevent persistence of dark mode styles when switching to light …

### DIFF
--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -181,16 +181,17 @@ const styles: Styles = {
 export const getStyles = (disableDarkMode: boolean) => {
   if (typeof window === 'undefined' || disableDarkMode) return styles;
   if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    const mergedStyles = { ...styles }
     for (const key in darkStyles) {
       if (Object.prototype.hasOwnProperty.call(darkStyles, key)) {
-        (styles as Record<string, any>)[key] = {
-          ...(Object.prototype.hasOwnProperty.call(styles, key) ? (styles as Record<string, any>)[key] : {}),
+        (mergedStyles as Record<string, any>)[key] = {
+          ...(Object.prototype.hasOwnProperty.call(mergedStyles, key) ? (mergedStyles as Record<string, any>)[key] : {}),
           ...(darkStyles as Record<string, any>)[key],
         };
       }
     }
 
-    return styles;
+    return mergedStyles;
   } 
   return styles;
 };


### PR DESCRIPTION
Resolved an issue where dark mode styles persisted when switching back to light mode.

Refactored the getStyles function to avoid mutating the original styles object by creating a shallow copy before applying dark mode styles. 

Light mode:
![image](https://github.com/user-attachments/assets/8a1c0b8e-c4b4-49c6-a93b-a10d80675961)

Dark mode:
![image](https://github.com/user-attachments/assets/af78d685-cdfc-451e-8cef-72fcc33597da)
