### PR TITLE
Update useColorPicker.ts to use current selected value from picker

### DIFF
--- a/src/hooks/useColorPicker.ts
+++ b/src/hooks/useColorPicker.ts
@@ -12,12 +12,16 @@ export const useColorPicker = (
   value: string,
   onChange: (arg0: string) => void
 ) => {
-  const colors = getColors(value)
+  let colors = getColors(value)
   const { degrees, degreeStr, isGradient, gradientType } = getDetails(value)
   const { currentColor, selectedColor, currentLeft } = getColorObj(colors)
   const [previousColors, setPreviousColors] = useState([])
 
-  const getGradientObject = () => {
+  const getGradientObject = (currentValue: string) => {
+    if (currentValue)
+    {
+      colors = getColors(currentValue)
+    }
     if (value) {
       if (isGradient) {
         return {


### PR DESCRIPTION
I like to create a component that contains ColorPicker and I like to pass the gradient object to the upper component. 
getGradientObject not returning the correct object coz color not updated  with value yet. this happens for value to hex too.
like this

```typescript
const [color, setColor] = useState('rgba(70,70,142,1)');
const { getGradientObject, valueToHex } = useColorPicker(color, setColor);

function onChange(value: string) {
  setColor(value);
  
  if (props.onChange) {
	  const g = getGradientObject();
	  props.onChange(value, g.isGradient ? g : undefined);
  }
}
```

```JSX
<ColorPicker value={color} onChange={onChange} width={290} />
```